### PR TITLE
🎉 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [2.0.1-develop.1](https://github.com/sebbo2002/vestaboard/compare/v2.0.0...v2.0.1-develop.1) (2023-05-02)
+
 # [2.0.0](https://github.com/sebbo2002/vestaboard/compare/v1.0.1...v2.0.0) (2023-03-31)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [3.0.0-develop.1](https://github.com/sebbo2002/vestaboard/compare/v2.0.1-develop.1...v3.0.0-develop.1) (2023-06-14)
+
+
+### Build System
+
+* Deprecate node.js v14 / v17 ([7a2de45](https://github.com/sebbo2002/vestaboard/commit/7a2de45c12f19a1ec441b3a004f4aa935efc197c))
+
+
+### BREAKING CHANGES
+
+* The node.js versions v14 and v17 are no longer maintained and are therefore no longer supported. See https://nodejs.dev/en/about/releases/ for more details on node.js release cycles.
+
 ## [2.0.1-develop.1](https://github.com/sebbo2002/vestaboard/compare/v2.0.0...v2.0.1-develop.1) (2023-05-02)
 
 # [2.0.0](https://github.com/sebbo2002/vestaboard/compare/v1.0.1...v2.0.0) (2023-03-31)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # `@sebbo2002/vestaboard`
 
 [![MIT LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/sebbo2002/vestaboard/blob/develop/LICENSE)
-[![CI Status](https://img.shields.io/github/workflow/status/sebbo2002/vestaboard/Test%20%26%20Release?style=flat-square)](https://github.com/sebbo2002/vestaboard/actions)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/sebbo2002/vestaboard/test-release.yml?style=flat-square)](https://github.com/sebbo2002/vestaboard/actions)
 
 <br />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "typescript": "^4.7.4"
       },
       "engines": {
-        "node": "^14.8.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": "^14.8.0 || >=16.0.0"
+    "node": "^16.0.0 || >=18.0.0"
   },
   "exports": {
     "import": "./dist/lib/index.js",


### PR DESCRIPTION
### ℹ️ About this release
* **Version**: 3.0.0
* **Type**: major
* **Last Release**: 2.0.0 (3/31/2023, 4:34:23 PM) [[?](https://github.com/sebbo2002/vestaboard/commit/a1c8e0aafa53451f4d88cf9adb85ab42f8490fdc)]
* **Commits to merge**: 5 [[?](https://github.com/sebbo2002/vestaboard/compare/sebbo2002:a1c8e0a...sebbo2002:dcb7713)]
### Build System

* Deprecate node.js v14 / v17 ([7a2de45](https://github.com/sebbo2002/vestaboard/commit/7a2de45c12f19a1ec441b3a004f4aa935efc197c))


### ⚡️ BREAKING CHANGES

* The node.js versions v14 and v17 are no longer maintained and are therefore no longer supported. See https://nodejs.dev/en/about/releases/ for more details on node.js release cycles.